### PR TITLE
Update L.swift

### DIFF
--- a/Sources/SwiftLexicon/L.swift
+++ b/Sources/SwiftLexicon/L.swift
@@ -5,7 +5,7 @@
 open class L: @unchecked Sendable, Hashable, I {
     open class var localized: String { "" }
     public let __: String
-    public init(_ id: String) { __ = id }
+    public required init(_ id: String) { __ = id }
 }
 
 public extension L {


### PR DESCRIPTION
> Constructing an object of class type 'T' with a metatype value must use a 'required' initializer

To allow for initialisation of `L` outside of SwiftLexicon we must ensure `L` has a required initialiser, this is particularly useful if you want to `cast` the type to another one whilst still preserving the original identifier