### PR TITLE
Update TaskPaper.swift - Indent inherited nodes one deeper to match MindNode

### DIFF
--- a/Sources/Lexicon/TaskPaper.swift
+++ b/Sources/Lexicon/TaskPaper.swift
@@ -151,7 +151,7 @@ public extension TaskPaper {
 				lines.append("\(tabs)= \(protonym)")
 			} else {
 				for type in node.type.sorted(by: <) {
-					lines.append("\(tabs)+ \(type)")
+					lines.append("\(tabs)\t+ \(type)")
 				}
 			}
 		}


### PR DESCRIPTION
Indent inherited nodes one level deeper to match output of MindNode (helps with diff when trying to work with both tools)